### PR TITLE
替换createFilter出处，解决不兼容Vite@2.x问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/yysanf/vite-plugin-replace-color/tree/master/#readme",
   "devDependencies": {
     "@rollup/plugin-typescript": "^9.0.2",
+    "@rollup/pluginutils": "^5.0.2",
     "@types/node": "^18.11.8",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.42.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Plugin } from "vite";
 import { formatHex, parseRgba, colorReg } from "./utils";
-import { createFilter } from "vite";
+import { createFilter } from "@rollup/pluginutils";
 
 export interface Options {
   colorVariables: Record<string, string | { hex?: string; rgb?: string }>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,7 +75,7 @@
     "@rollup/pluginutils" "^5.0.1"
     resolve "^1.22.1"
 
-"@rollup/pluginutils@^5.0.1":
+"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.0.2":
   version "5.0.2"
   resolved "https://registry.npmmirror.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
   integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==


### PR DESCRIPTION
使用rollup插件@rollup/pluginutils
可以兼容vite@2.x